### PR TITLE
Don't encourage users to put the embed code at the bottom of the page and add some links.

### DIFF
--- a/plugins/sublimevideo/sublimevideo.mdown
+++ b/plugins/sublimevideo/sublimevideo.mdown
@@ -9,19 +9,21 @@
 	
 ## What is it?
 
-This plugin is just a Kirbytext extension, in order to easily use the SublimeVideo HTML player. It provides you with a new tag:
+This plugin is just a Kirbytext extension, in order to easily use the [SublimeVideo HTML5 Player](http://sublimevideo.net/). It provides you with a new tag:
 
-	(sublime: file-name video1: ext1 video2: ext2 poster: jpg width: xxx height: yyy)
+`(sublime: file-name video1: ext1 video2: ext2 poster: jpg width: xxx height: yyy)`
 
 ## Installation
 
 1. Copy the `sublimevideo.php` file into your `site/plugins` folder. If the plugins folder doesn't exist yet, please create it. As a plugin, the file will be automatically loaded by Kirby.
 
-2. Put your SublimeVideo script/token in the header  of your site (or in the footer just before the closing `</body>`). It should look like this :
+2. Put your SublimeVideo embed code inside the `<head>` tag of your site. It should look like this :
 
-	<script type="text/javascript" src="http://cdn.sublimevideo.net/js/YOUR_TOKEN.js"></script>
+```html
+<script type="text/javascript" src="http://cdn.sublimevideo.net/js/YOUR_TOKEN.js"></script>
+```
 
-> Please note that you need to have a SublimeVideo account (free). This service is very easy to use but if you need help, please refer to their documentation. I am also not going to discuss video encoding here.
+Please note that you need to have a [SublimeVideo account](http://sublimevideo.net/plans) (free). This service is very easy to use but if you need help, please refer to [their documentation](http://docs.sublimevideo.net/quickstart-guide). I am also not going to discuss [video encoding](http://docs.sublimevideo.net/encode-videos-for-the-web) here.
 
 ## How to use it?
 


### PR DESCRIPTION
Hi!

I'm Rémy from SublimeVideo. Cool plugin, thanks! :)

I've made a few changes:
- Don't encourage users to put the embed code at the bottom of the page (see why [here](http://docs.sublimevideo.net/quickstart-guide));
- Added some links to the documentation and site.

Also, the approach you're using to declare the sources is limited in the sense that you could totally provide two MP4 files, one for desktop playback and one for mobile playback (with a lower resolution/bitrate). So I think forcing the user to set the same name for all sources is not a good choice here.

For instance, in the [WordPress plugin](http://docs.sublimevideo.net/wordpress#shortcode-documentation) I simply used `src1`, `src2` etc... (with as many `srcX` as the user wants) so the user is totally free to name his video files as he wants (with possibly multiple files with the same extension).

It would be also great to support the new [HD Switching](http://docs.sublimevideo.net/hd-switching) feature at some point! :)

It would also be kick-ass to support the [`data-uid` and `data-name` attributes](http://docs.sublimevideo.net/optimize-for-stats)! ;-)

Anyway, thanks for developing SublimeVideo third-party plugins, it's really cool for the whole SublimeVideo ecosystem!
