### PR TITLE
Ensure <source> tags end with "/"

### DIFF
--- a/plugins/sublimevideo/sublimevideo.php
+++ b/plugins/sublimevideo/sublimevideo.php
@@ -90,7 +90,7 @@ class kirbytextExtended extends kirbytext {
       // check for hd quality 
       $hd = ($video->hd()) ? ' data-quality="hd"' : '';
       // generate the source tag for each video
-      $html .= '<source src="' . $video->url() . '"' . $hd . '>';
+      $html .= '<source src="' . $video->url() . '"' . $hd . ' />';
     }
     $html .= '</video>';
         


### PR DESCRIPTION
This is necessary to ensure compatibility with IE 6, 7, 8.

More infos here: http://docs.sublimevideo.net/write-proper-video-elements
