### PR TITLE
Just a cool solid tweak on field:tags extension..

### DIFF
--- a/fields/tags/readme.mdown
+++ b/fields/tags/readme.mdown
@@ -111,3 +111,22 @@ If you don't want to fetch suggestions from other pages, you can set your own ar
 				- development
 				- web
 
+
+### Global setup
+
+If you do not want to setup 'index: template' or 'index: siblings' for each of your site's template files (ie, default.php) just because it's different from the default tag setup, simply put the following within your config.php file
+
+	/*
+
+	---------------------------------------
+	Panels Fields Defaults
+	---------------------------------------
+
+	Change the default file extension for your
+	content files here if you'd rather use something
+	else than txt. For example md or mdown.
+
+	*/
+
+    c::set('fields.tags.index', 'siblings');
+

--- a/fields/tags/tags.php
+++ b/fields/tags/tags.php
@@ -11,16 +11,23 @@ $separator = (isset($separator)) ? $separator : ',';
 // field to fetch existing tags from
 $field = (isset($field)) ? $field : $name;
 
+// field to fetch existing tags from (since by default there was none, but you might want
+// to establish a default in your site config via c::set(field.tags.index)
+$default_index = trim(c::get('fields.tags.index'));
+$index = (isset($index)) ? $index : ( ( !empty($default_index) ) ? $default_index : '' );
+
 // lowercase all tags
 $lower = (isset($lower)) ? $lower : false;
 
 // use passed data if available or try to fetch data
 if(!isset($data) || !is_array($data)) {
 
-  $data  = array();
-  $store = array();
-  
+	$data  = array();
+	$store = array();
+
   switch($index) {
+	// Need to establish a default otherwise PHP Error 'Notices' can occur (if not suppressed)
+	default:
     case 'template':
       foreach($site->pages()->index() as $p) {
         if($p->template() == $page->template()) $store[] = $p;
@@ -36,7 +43,7 @@ if(!isset($data) || !is_array($data)) {
   
   // get all tags
   foreach($store as $s) {
-    $data = array_merge($data, str::split($s->{$field}, $separator));
+	  $data = array_merge($data, str::split($s->{$field}, $separator));
   }
 
 }


### PR DESCRIPTION
Reason is that when there's no 'index: template' spec'd then it's blank and under strict notices showing all warnings etc.. there's an issue with the arrays and/without a default in the switch case I was getting warnings spit out... 

So i added a 'default' - but also (above that in tags.php) i added a check to confirm that an index has been chosen and to also check if there's been one established in the config.php. check tags.mdown for that verbiage (near bottom)

Hope this helps.
