### PR TITLE
Error in Dribbble Plugin

### DIFF
--- a/plugins/dribbble/dribbble.php
+++ b/plugins/dribbble/dribbble.php
@@ -216,7 +216,7 @@ class dribbble {
 
             // Load data & close connection
             $data = curl_exec($handler);
-            curl_close($ch);  
+            curl_close($handler);  
         
             return $data;
         }


### PR DESCRIPTION
The call to curl_close at the bottom of dribbble.php was referencing an undefined variable and therefor causing a PHP error.
