### PR TITLE
Search - uid may not always be unique

### DIFF
--- a/plugins/search/search.php
+++ b/plugins/search/search.php
@@ -146,9 +146,9 @@ class search {
       
       // add all matched pages to the result set  
       if($matchedTotal) {            
-        $result[$page->uid] = $page;      
-        $result[$page->uid]->searchHits  = $matchedTotal;
-        $result[$page->uid]->searchScore = $score;
+        $result[$page->uri] = $page;      
+        $result[$page->uri]->searchHits  = $matchedTotal;
+        $result[$page->uri]->searchScore = $score;
       }
                 
     }  


### PR DESCRIPTION
The search plugin uses the uid instead of the full uri. A site can have multiple pages with the same name under different directories. Using the uid causes the search to only find the 'last' result in the set with the same uid.
