### PR TITLE
remove extra <br> tags, post Geshi parse

### DIFF
--- a/plugins/highlight/highlight.php
+++ b/plugins/highlight/highlight.php
@@ -13,6 +13,7 @@ function highlight($code, $lang) {
   $geshi->enable_classes();
   $geshi->enable_keyword_links(false);
   $code  = $geshi->parse_code();
+  $code = str_replace('<br />', '', $code);
   return '<span class="' . $lang . '">' . $code . '</span>';
 
 }


### PR DESCRIPTION
I added some additional langages from the Geshi package for a site I'm working on and noticed I kept getting double `<br>` tags every time I had a newline in my content txt files. I think the markdown parser is adding `<br>`'s as well as Geshi, hence the doubling.
