### PR TITLE
Added option to read tags from files metadata

### DIFF
--- a/plugins/tagcloud/tagcloud.php
+++ b/plugins/tagcloud/tagcloud.php
@@ -25,6 +25,9 @@ function tagcloud($parent, $options=array()) {
     case 'visible':
       $children = $parent->children()->visible();
       break;
+	case 'files':
+	  $children = $parent->files();
+	  break; 	
     default:
       $children = $parent->children();
       break;


### PR DESCRIPTION
Added 'files' as a valid value for the 'children' option in tagcloud
plugin to read tag information from files meta data (eg:
IMG_0456.txt.JPG)
