### PR TITLE
Dev: Added different Flickr-requestTypes

### DIFF
--- a/plugins/flickrbadge/readme.mdown
+++ b/plugins/flickrbadge/readme.mdown
@@ -74,6 +74,23 @@ Disable or enable the cache. Caching the results is highly recommended. Otherwis
 
 Set the cache expiry in seconds. By default it will be set to two hours. After two hours the badge will try to fetch fresh data from the API. Photo and user information will be kept forever unless you delete the cache files manually. This will speed up the update process. 
 
+### requestType (default: user)
+
+Set the type of request you want to perform.
+user: get your latest images
+set: get latest images of a set
+favorites: get your latest favorites
+gallery: get latest images of a certain gallery
+
+### set
+
+Set the ID of a set (required for requestType set)
+
+### gallery
+
+Set the URL of a gallery (required for requestType gallery)
+
+
 ## Available variables for $picture objects
 
 When looping through the result array you can use the following variables:

--- a/plugins/flickrbadge/readme.mdown
+++ b/plugins/flickrbadge/readme.mdown
@@ -77,10 +77,10 @@ Set the cache expiry in seconds. By default it will be set to two hours. After t
 ### requestType (default: user)
 
 Set the type of request you want to perform.
-user: get your latest images
-set: get latest images of a set
-favorites: get your latest favorites
-gallery: get latest images of a certain gallery
+- user: get your latest images
+- set: get latest images of a set
+- favorites: get your latest favorites
+- gallery: get latest images of a certain gallery
 
 ### set
 

--- a/plugins/flickrbadge/readme.mdown
+++ b/plugins/flickrbadge/readme.mdown
@@ -77,10 +77,10 @@ Set the cache expiry in seconds. By default it will be set to two hours. After t
 ### requestType (default: user)
 
 Set the type of request you want to perform.
-- user: get your latest images
-- set: get latest images of a set
-- favorites: get your latest favorites
-- gallery: get latest images of a certain gallery
+- user
+- set
+- favorites
+- gallery
 
 ### set
 


### PR DESCRIPTION
Added the possibility to use different requestTypes:
- user (default) for requesting your latest images
- set to get the latest photos of a certain set
- gallery to get the latest photos of a certain gallery
- favorites to get your latest favorites

If requesting photos of a set, the ID of the set must be given
If requesting photos of a gallery the URL of the set must be given (there is no way to get the ID of the gallery directly on flickr.com)

If no requestType is given, the requestType 'user' is used to obtain backward-compatibility.
