### PR TITLE
Added option to generate progressive JPEGs

### DIFF
--- a/plugins/thumb/readme.mdown
+++ b/plugins/thumb/readme.mdown
@@ -53,6 +53,10 @@ If set to true RGB images will be converted to grayscale
 
 If set to true image URLs will be converted to data:URIs
 
+### progressive
+
+If set to true JPEG thumbs will be progressive.
+
 ## Available settings
 
 You can add the following config variables to your config file (site/config/config.php) to adjust the default settings of the thumb plugin:

--- a/plugins/thumb/thumb.php
+++ b/plugins/thumb/thumb.php
@@ -26,6 +26,7 @@ class thumb {
   var $crop = false;
   var $grayscale = false;
   var $datauri = false;
+  var $progressive = false;
 
   function __construct($image, $options=array()) {
 
@@ -53,6 +54,9 @@ class thumb {
     
     // set greyscale on/off
     $this->grayscale = @$options['grayscale'];
+    
+    // set progressive jpegs on/off
+    $this->progressive = @$options['progressive'];
 	
     // set the quality
     $this->quality = a::get($options, 'quality', c::get('thumb.quality', 100));
@@ -263,7 +267,11 @@ class thumb {
 	if($this->grayscale == true) {
 		imagefilter($thumb, IMG_FILTER_GRAYSCALE);
 	}
-    
+
+    if($this->mime == 'image/jpeg') {
+      imageinterlace($thumb, $this->progressive);
+    }
+
     switch($this->mime) {
       case 'image/jpeg': imagejpeg($thumb, $file, $this->quality); break;
       case 'image/png' : imagepng($thumb, $file, 0); break; 


### PR DESCRIPTION
Per issue #33 I thought I'd try my hand at adding an option for progressive JPEGs. @DerZyklop was simply using the imageinterlace function on the wrong image. We want to set the progressive bit on the $thumb farther down the page. After making sure it worked I added an option to turn it on... Perhaps it should be a setting in the config to "set it and forget it?" 
