### PR TITLE
ContactForm: Skip form redirect if goto option is empty

### DIFF
--- a/plugins/contactform/contactform.php
+++ b/plugins/contactform/contactform.php
@@ -51,7 +51,10 @@ class ContactForm extends Submission {
     // redirect to the "goto" url on success
     $this->defaults('success', function($self) {
       // redirect to callback url
-      go($self->option('goto'));
+      $url = $self->option('goto');
+      if (!empty($url)) {
+        go($self->option('goto'));
+      }
     });
 
     // merge the defaults with the given options


### PR DESCRIPTION
Just a small addition that allows to skip the form redirect after successful submission. 

I wanted to display the message sent by the user, but had no access to the form data after the redirect. With the proposed fix developers at least have the chance to skip the default behavior by passing false/null as goto option.
