### PR TITLE
GitHub API requires User Agent

### DIFF
--- a/plugins/github/github.php
+++ b/plugins/github/github.php
@@ -70,7 +70,7 @@ class github {
 
         curl_setopt($handler, CURLOPT_URL, $url);
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($handler, CURLOPT_USERAGENT, $this->username);
+        curl_setopt($handler, CURLOPT_USERAGENT, $this->username);
 
         $data = curl_exec($handler);
         curl_close($handler);


### PR DESCRIPTION
The GitHub API requires to set a user agent. Added the username to fulfill this requirement.
