### PR TITLE
Fixes from action URL

### DIFF
--- a/plugins/auth/snippets/login.php
+++ b/plugins/auth/snippets/login.php
@@ -1,6 +1,6 @@
 <?php $login = Auth::login() ?>
 
-<form action="<?php $page->url() ?>" method="post">
+<form action="<?php echo $page->url() ?>" method="post">
 
   <?php if($login): ?>
   <div class="alert">


### PR DESCRIPTION
Nothing was being echoed. Now the page’s URL is put in the form action attribute so the `alert` state is properly triggered if an error occurs on submission.
