### PR TITLE
Tagcloud: urlify to compare with url param

### DIFF
--- a/plugins/tagcloud/tagcloud.php
+++ b/plugins/tagcloud/tagcloud.php
@@ -45,8 +45,8 @@ function tagcloud($parent, $options=array()) {
         $cloud[$t] = new obj(array(
           'results'  => 1,
           'name'     => $t,
-          'url'      => $options['baseurl'] . '/' . $options['param'] . $ds . $t, 
-          'isActive' => (param($options['param']) == $t) ? true : false,
+          'url'      => $options['baseurl'] . $options['param'] . $ds . str::urlify($t), 
+          'isActive' => (param($options['param']) == str::urlify($t)) ? true : false,
         ));
       }
       


### PR DESCRIPTION
Hey Bastian—
Some explanation first, why I think this is necessary: I combined the tagcloud plugin and the tag field type to create a self-generating submenu of categories in a blog. The posts would be filtered in accordance to a url parameter. So the links in the submenu would be something like this:

```
/blog/c:foo
/blog/c:bar
```

As it is a catalan/spanish site, I had some issues with accents— both being passed by url, and later correctly recognizing tags as active.
I could fix this by passing a urlified string and comparing that to an urlified version of the tags.
