### PR TITLE
added poster attribute to video snippet

### DIFF
--- a/snippets/video/video.php
+++ b/snippets/video/video.php
@@ -9,12 +9,13 @@ if(!isset($height))   $height   = 300;
 if(!isset($preload))  $preload  = true;
 if(!isset($controls)) $controls = true;
 
-// build the html tags for the video element
+// build the html atts for the video element
 $preload  = ($preload)  ? ' preload="preload"'   : '';
 $controls = ($controls) ? ' controls="controls"' : '';
+$poster = ($thumb) ? ' poster="'. $thumb->url() .'"' : '';
 
 ?>
-<video width="<?php echo $width ?>" height="<?php echo $height ?>"<?php echo $preload . $controls ?>>
+<video width="<?php echo $width ?>" height="<?php echo $height ?>"<?php echo $preload . $controls . $poster ?>>
   <?php foreach($videos as $video): ?>
   <source src="<?php echo $video->url() ?>" type="<?php echo $video->mime() ?>" />
   <?php endforeach ?>


### PR DESCRIPTION
The "thumb" parameter is not named appropriately. It does not set a thumbnail image but rather a fallback image for browsers that can not handle the HTML5 video element. As a result modern browsers will have no use for this parameter.

This commit adds the "thumb" URL to the "poster" attribute and thus displays a thumbnail before the video starts to play.

The solution is not perfect as "thumb" is still a misleading name that is not covered by the HTML spec. I think it would be best to introduce two new variables named "poster" and "fallback" that correspond to their actual function in the code. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
