### PR TITLE
Safari and Frontend Authentication

### DIFF
--- a/plugins/auth/auth.php
+++ b/plugins/auth/auth.php
@@ -45,7 +45,7 @@ class Auth {
     
     // store the token in the cookie
     // and the user data in the session    
-    cookie::set('authFrontend', $token, 60*60*24);    		
+    cookie::set('authFrontend', $token, 60*60*24, '/');  		
 		s::set('authFrontend.' . $token, $account->username());
     		
 		go(url($redirect));
@@ -84,7 +84,7 @@ class Auth {
     // overwrite the token      
     $token = str::random();
     // the cookie is valid for 24 hours
-    cookie::set('authFrontend', $token, 60*60*24);
+    cookie::set('authFrontend', $token, 60*60*24, '/');
     
     // restart the session    
     s::restart();

--- a/plugins/auth/auth.php
+++ b/plugins/auth/auth.php
@@ -45,7 +45,7 @@ class Auth {
     
     // store the token in the cookie
     // and the user data in the session    
-    cookie::set('authFrontend', $token, 60*60*24, '/');  		
+    cookie::set('authFrontend', $token, 60*60*24);    		
 		s::set('authFrontend.' . $token, $account->username());
     		
 		go(url($redirect));
@@ -84,7 +84,7 @@ class Auth {
     // overwrite the token      
     $token = str::random();
     // the cookie is valid for 24 hours
-    cookie::set('authFrontend', $token, 60*60*24, '/');
+    cookie::set('authFrontend', $token, 60*60*24);
     
     // restart the session    
     s::restart();

--- a/plugins/auth/auth.php
+++ b/plugins/auth/auth.php
@@ -45,7 +45,7 @@ class Auth {
     
     // store the token in the cookie
     // and the user data in the session    
-    cookie::set('authFrontend', $token, 60*60*24);    		
+    cookie::set('authFrontend', $token, 60*60*24, '/');    		
 		s::set('authFrontend.' . $token, $account->username());
     		
 		go(url($redirect));
@@ -84,7 +84,7 @@ class Auth {
     // overwrite the token      
     $token = str::random();
     // the cookie is valid for 24 hours
-    cookie::set('authFrontend', $token, 60*60*24);
+    cookie::set('authFrontend', $token, 60*60*24, '/');
     
     // restart the session    
     s::restart();


### PR DESCRIPTION
Safari was having problems with frontend authentication, adding a "/"  to the end of cookie::set solved the issue.

For a full description of the issue, go here: http://getkirby.com/forum/issue-tracker/20141011/safari-and-frontend-authentication
